### PR TITLE
Fix AUTO_INCREMENT for complex primary keys

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -640,7 +640,11 @@ function mixinMigration(MySQL, mysql) {
           return;
         }
         var colName = self.columnEscaped(model, prop);
-        sql.push(colName + ' ' + self.buildColumnDefinition(model, prop));
+
+        if (definition.properties[prop].generated)
+          sql.push(colName + ' ' + self.buildColumnDefinition(model, prop) + ' AUTO_INCREMENT ');
+        else
+          sql.push(colName + ' ' + self.buildColumnDefinition(model, prop));
       });
       if (pks.length > 1) {
         sql.push('PRIMARY KEY(' + pks.join(',') + ')');


### PR DESCRIPTION
In case we are use complex primary keys, one or many of them can be auto incremented fields. So I think need to add AUTO_INCREMENT without check PRIMIRY is simple or complex.

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
